### PR TITLE
Add tournament registrations, match builder and advanced scoring

### DIFF
--- a/padel_local_demo/README.md
+++ b/padel_local_demo/README.md
@@ -1,7 +1,11 @@
 # Padel Tournois — Demo locale
 Ouvrez `index.html` dans votre navigateur (double-clic). Les données sont stockées en LocalStorage.
-Fonctions: joueurs/paires, tournois (métadonnées), sélection de match, scoring live simple avec Undo,
-export/import JSON, reset, et données de démo.
+Fonctions :
+- gestion des joueurs et des paires (avec têtes de série),
+- création de tournois + inscriptions de paires,
+- création de matchs entre paires inscrites,
+- scoring live complet (15/30/40, tie-break, super tie-break) avec Undo,
+- export/import JSON, reset, et données de démo.
 
 Astuce: si votre navigateur limite l'accès aux fichiers, lancez un mini-serveur local:
 - Python: `python -m http.server 8000` puis ouvrez http://localhost:8000

--- a/padel_local_demo/index.html
+++ b/padel_local_demo/index.html
@@ -46,14 +46,31 @@
       <button>Créer tournoi</button>
     </form>
     <ul id="tournamentsList"></ul>
+
+    <h3>Inscriptions</h3>
+    <select id="tournamentSelect"></select>
+    <div id="registrationBox" class="hidden">
+      <form id="registrationForm">
+        <select name="pairId"></select>
+        <button>Inscrire</button>
+      </form>
+      <ul id="registrationList"></ul>
+    </div>
   </section>
 
   <!-- Matchs & live --------------------------------------------------------->
   <section id="view-matches" class="view hidden">
     <h2>Matchs</h2>
+    <form id="matchForm">
+      <select name="tournamentId"></select>
+      <select name="pair1Id"></select>
+      <select name="pair2Id"></select>
+      <button>Créer match</button>
+    </form>
     <select id="matchSelect"></select>
     <div id="scoreboard" class="hidden">
       <h3 id="matchTitle"></h3>
+      <div id="current"></div>
       <div id="sets"></div>
       <div class="buttons">
         <button id="p1Point">Point P1</button>

--- a/padel_local_demo/styles.css
+++ b/padel_local_demo/styles.css
@@ -1,24 +1,30 @@
 body {
-  font-family: sans-serif;
+  font-family: system-ui, sans-serif;
   margin: 0;
   padding: 0;
+  background: #f4f4f4;
 }
 nav {
   display: flex;
   gap: 4px;
-  background: #444;
+  background: #1e1e1e;
   padding: 8px;
 }
 nav button {
   flex: 1;
-  padding: 8px;
+  padding: 10px;
   color: #fff;
-  background: #666;
+  background: #3a3a3a;
   border: none;
   cursor: pointer;
+  transition: background 0.2s;
 }
-nav button:hover { background: #888; }
-.view { padding: 1rem; }
+nav button:hover { background: #575757; }
+.view {
+  padding: 1rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
 .hidden { display: none; }
 
 form {
@@ -26,16 +32,30 @@ form {
   flex-wrap: wrap;
   gap: 0.5rem;
   margin-bottom: 1rem;
+  background: #fff;
+  padding: 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
 form input, form select, form button {
   padding: 0.5rem;
 }
 
 ul { list-style: none; padding: 0; }
-li { margin: 4px 0; }
+li {
+  margin: 4px 0;
+  background: #fff;
+  padding: 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
 
 #scoreboard {
   margin-top: 1rem;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
 #sets div {
   margin-bottom: 0.5rem;


### PR DESCRIPTION
## Summary
- allow registering pairs to tournaments and building matches from registrations
- implement full tennis scoring with tie-break and super tie-break plus undo
- refresh layout with card-like forms and scoreboard styling

## Testing
- `node --check padel_local_demo/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7469910e88327b8e349845e85d80a