### PR TITLE
Add player profiles with search filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Ce projet fournit un service d'authentification minimal en Node.js sans dépenda
 - `POST /auth/login` – connexion, renvoie un JWT basique.
 - `GET /profile` – retourne le profil de l'utilisateur connecté.
 - `GET /players` – liste des joueurs enregistrés.
-- `POST /players` – ajoute un joueur (`firstName`, `lastName`, `license`).
+- `POST /players` – ajoute un joueur (`firstName`, `lastName`, `license`, `bio?`, `photo?`, `preferences?`, `ranking?`).
+- `GET /players/:id` – retourne le profil complet d'un joueur.
+- `GET /players?name=&minRanking=&maxRanking=` – recherche de joueurs.
 - `GET /pairs` – liste des paires.
 - `POST /pairs` – crée une paire (`p1`, `p2`, `seed`).
 - `GET /tournaments` – liste des tournois.

--- a/data/players.json
+++ b/data/players.json
@@ -3,12 +3,24 @@
     "id": "pfa9c512c-2eb6-451d-9092-d3e8fa7dd826",
     "firstName": "A",
     "lastName": "B",
-    "license": ""
+    "license": "",
+    "photo": "",
+    "bio": "",
+    "preferences": [],
+    "ranking": 0,
+    "stats": { "wins": 0, "losses": 0 },
+    "tournaments": []
   },
   {
     "id": "pfc65e86c-8a66-4605-a0cf-5c560590587f",
     "firstName": "C",
     "lastName": "D",
-    "license": ""
+    "license": "",
+    "photo": "",
+    "bio": "",
+    "preferences": [],
+    "ranking": 0,
+    "stats": { "wins": 0, "losses": 0 },
+    "tournaments": []
   }
 ]

--- a/test.js
+++ b/test.js
@@ -25,9 +25,11 @@ fs.writeFileSync('./data/pairs.json', '[]');
 fs.writeFileSync('./data/tournaments.json', '[]');
 
 // players and pairs
-const p1 = addPlayer({ firstName: 'A', lastName: 'B' });
-const p2 = addPlayer({ firstName: 'C', lastName: 'D' });
+const p1 = addPlayer({ firstName: 'A', lastName: 'B', ranking: 100, bio: 'player A' });
+const p2 = addPlayer({ firstName: 'C', lastName: 'D', ranking: 200 });
 assert(listPlayers().length === 2);
+assert(listPlayers({ name: 'A' }).length === 1);
+assert(listPlayers({ minRanking: 150 }).length === 1);
 const pairId = addPair(p1, p2, 1);
 assert(listPairs().some(p => p.id === pairId));
 


### PR DESCRIPTION
## Summary
- extend player data with photo, bio, preferences, ranking and stats
- support player lookup by id and filtering by name or ranking
- document new endpoints and sample player schema

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a759d815188327a3008b0707f720a9